### PR TITLE
Add a workflow to notifiy on PRs

### DIFF
--- a/.github/workflows/discord-pr-notifications.yml
+++ b/.github/workflows/discord-pr-notifications.yml
@@ -1,0 +1,143 @@
+name: 🔔 Discord PR Notifications
+
+on:
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # ================================
+  # Discord PR Notifications
+  # ================================
+  notify-discord:
+    name: Send Discord Notification
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Determine PR action details
+        id: pr_action
+        run: |
+          case "${{ github.event.action }}" in
+            "opened")
+              echo "color=3447003" >> $GITHUB_OUTPUT
+              echo "emoji=🆕" >> $GITHUB_OUTPUT
+              echo "text=opened" >> $GITHUB_OUTPUT
+              ;;
+            "reopened")
+              echo "color=16776960" >> $GITHUB_OUTPUT
+              echo "emoji=🔄" >> $GITHUB_OUTPUT
+              echo "text=reopened" >> $GITHUB_OUTPUT
+              ;;
+            "closed")
+              if [ "${{ github.event.pull_request.merged }}" == "true" ]; then
+                echo "color=65280" >> $GITHUB_OUTPUT
+                echo "emoji=✅" >> $GITHUB_OUTPUT
+                echo "text=merged" >> $GITHUB_OUTPUT
+              else
+                echo "color=16711680" >> $GITHUB_OUTPUT
+                echo "emoji=❌" >> $GITHUB_OUTPUT
+                echo "text=closed" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "ready_for_review")
+              echo "color=3447003" >> $GITHUB_OUTPUT
+              echo "emoji=👀" >> $GITHUB_OUTPUT
+              echo "text=marked as ready for review" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=📝" >> $GITHUB_OUTPUT
+              echo "text=${{ github.event.action }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Extract commit SHA
+        id: commit
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Send Discord notification
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Actions"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-title: "${{ steps.pr_action.outputs.emoji }} Pull Request ${{ steps.pr_action.outputs.text }}"
+          embed-description: |
+            **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
+            
+            🌿 Branch: \`${{ github.event.pull_request.head.ref }}\` → \`${{ github.event.pull_request.base.ref }}\`
+            👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
+            📊 Changes: +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
+            📦 Commit: \`${{ steps.commit.outputs.short_sha }}\`
+            
+            [View Pull Request →](${{ github.event.pull_request.html_url }})
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-color: ${{ steps.pr_action.outputs.color }}
+          embed-thumbnail-url: ${{ github.event.pull_request.user.avatar_url }}
+          embed-footer-text: "Homepedia"
+          embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-timestamp: ${{ github.event.pull_request.created_at }}
+
+  # ================================
+  # Review notifications
+  # ================================
+  notify-review:
+    name: Send Review Notification
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review'
+
+    steps:
+      - name: Determine review details
+        id: review_action
+        run: |
+          case "${{ github.event.review.state }}" in
+            "approved")
+              echo "color=65280" >> $GITHUB_OUTPUT
+              echo "emoji=✅" >> $GITHUB_OUTPUT
+              echo "text=approved" >> $GITHUB_OUTPUT
+              ;;
+            "changes_requested")
+              echo "color=16711680" >> $GITHUB_OUTPUT
+              echo "emoji=❌" >> $GITHUB_OUTPUT
+              echo "text=requested changes" >> $GITHUB_OUTPUT
+              ;;
+            "commented")
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=💬" >> $GITHUB_OUTPUT
+              echo "text=commented" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "color=9936031" >> $GITHUB_OUTPUT
+              echo "emoji=📝" >> $GITHUB_OUTPUT
+              echo "text=${{ github.event.review.state }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Send review notification
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: "GitHub Actions"
+          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-title: "${{ steps.review_action.outputs.emoji }} PR Review ${{ steps.review_action.outputs.text }}"
+          embed-description: |
+            **PR #${{ github.event.pull_request.number }}**: ${{ github.event.pull_request.title }}
+            
+            👤 Reviewer: [${{ github.event.review.user.login }}](${{ github.event.review.user.html_url }})
+            👤 Author: [${{ github.event.pull_request.user.login }}](${{ github.event.pull_request.user.html_url }})
+            
+            [View Review →](${{ github.event.review.html_url }})
+          embed-url: ${{ github.event.review.html_url }}
+          embed-color: ${{ steps.review_action.outputs.color }}
+          embed-thumbnail-url: ${{ github.event.review.user.avatar_url }}
+          embed-footer-text: "Homepedia"
+          embed-footer-icon-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          embed-timestamp: ${{ github.event.review.submitted_at }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for sending Discord notifications about pull request activity and reviews. The workflow automates Discord updates for various PR and review events, improving team visibility and communication.

Workflow automation for Discord notifications:

* Added `.github/workflows/discord-pr-notifications.yml` to send Discord notifications for pull request events (opened, reopened, closed, ready for review) and review submissions, using the `tsickert/discord-webhook` action.
* Implemented logic to customize notification content and color based on the PR action (e.g., opened, merged, closed) and review state (e.g., approved, changes requested, commented).
* Included detailed PR and review information in notifications, such as branch names, commit SHA, author/reviewer profiles, and links to the relevant GitHub pages.