### PR TITLE
Fix Docker dev container permissions and isolate node_modules

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@ up ENV:
     if [ "{{ENV}}" = "doc" ]; then
         docker compose -f docker/{{ENV}}/compose.yml up --detach
     elif [ "{{ENV}}" = "dev" ]; then
-        docker compose -f compose.dev.yml up --detach
+        UID=$(id -u) GID=$(id -g) docker compose -f compose.dev.yml up --detach --build
     elif [ "{{ENV}}" = "prod" ]; then
         docker compose -f compose.prod.yml up --detach --build
     else

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -5,13 +5,14 @@ services:
     build:
       context: webapp
       dockerfile: docker/dev/Dockerfile
+      args:
+        USER_UID: "${UID:?}"
+        USER_GID: "${GID:?}"
     container_name: homepedia-webapp-dev
     ports:
       - "5173:5173"
     volumes:
       - ./webapp:/app
-      # Préserver les node_modules du container (évite l'écrasement par le bind mount)
-      - /app/node_modules
     environment:
       - NODE_ENV=development
       # Variables Vite à définir si nécessaire :

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -2,6 +2,31 @@
 
 This is a template for a new Vite project with React, TypeScript, and shadcn/ui.
 
+## Development setup
+
+### Running with Docker
+
+The development container is managed through `just`. To start the webapp:
+
+```bash
+just up dev
+```
+
+This will build the Docker image and start the container with Vite's dev server available at `http://localhost:5173`.
+
+### Installing dependencies locally
+
+Inside the container, `node_modules` are installed in a separate directory (`/deps/node_modules`) and symlinked into the project at startup. This avoids Docker creating a root-owned `node_modules` folder on the host through the bind mount.
+
+However, your editor (e.g. VSCode) relies on a local `node_modules` directory to resolve types and provide autocompletion. You need to install dependencies on the host as well:
+
+```bash
+cd webapp
+npm ci
+```
+
+Both installs are independent: the container uses its own modules from `/deps`, while the host installation is only used by your editor.
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/webapp/docker/dev/Dockerfile
+++ b/webapp/docker/dev/Dockerfile
@@ -1,13 +1,24 @@
 FROM node:22-alpine
 
-WORKDIR /app
+ARG USER_UID=1000
+ARG USER_GID=1000
 
-# Installer les dépendances en premier pour tirer parti du cache Docker
-COPY package*.json ./
+# Aligner l'UID/GID de l'utilisateur node avec l'utilisateur local
+RUN delgroup node 2>/dev/null; deluser node 2>/dev/null; \
+    addgroup -g ${USER_GID} node && \
+    adduser -u ${USER_UID} -G node -s /bin/sh -D node
 
+USER node
+
+# Installer les dépendances hors du bind mount
+# pour éviter qu'un dossier node_modules root apparaisse sur l'hôte
+WORKDIR /deps
+COPY --chown=node:node package*.json ./
 RUN npm ci
 
-# Le code source est monté via bind mount en dev
+WORKDIR /app
+
 EXPOSE 5173
 
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+# Symlink node_modules dans /app après le bind mount, puis lancer vite
+CMD ["sh", "-c", "ln -sf /deps/node_modules /app/node_modules && npm run dev -- --host 0.0.0.0"]


### PR DESCRIPTION
## Summary

- Run dev container as non-root user with host UID/GID alignment to fix bind mount permission issues
- Install `node_modules` in `/deps` and symlink at startup to prevent a root-owned `node_modules` on the host
- Document the dev setup and why a local `npm ci` is needed for editor support

Closes #22

## Test plan

- [ ] Run `just up dev` and verify the container starts without errors
- [ ] Check that Vite dev server is accessible at `http://localhost:5173`
- [ ] Verify no root-owned `node_modules` directory appears on the host
- [ ] Run `npm ci` locally and confirm VSCode resolves types correctly