### PR TITLE
fix: correctifs pour faire tourner le stack DVF de bout en bout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 .env.*
 !.env.*.example
+
+.idea/**

--- a/pipelines/dvf/conf/base/parameters.yml
+++ b/pipelines/dvf/conf/base/parameters.yml
@@ -1,8 +1,10 @@
 # Paramètres métier du pipeline DVF (cf. méthodologie validée en Phase 1).
 
-# Source du CSV brut Geo DVF 2025 (data.gouv.fr). Téléchargé par le node
+# Source du CSV brut Geo DVF (millésime 2024). Téléchargé par le node
 # ensure_raw_csv s'il est absent de data/01_raw/ (reproductibilité depuis un clone).
-geo_dvf_source_url: https://www.data.gouv.fr/api/1/datasets/r/316795eb-a3fa-465d-b058-38ef8579da11
+# NB : l'ID stable data.gouv (316795eb-…) redirige vers le listing du dossier,
+# qui renvoie 404 — seul le chemin direct du millésime est servi.
+geo_dvf_source_url: https://files.data.gouv.fr/geo-dvf/latest/csv/2024/full.csv.gz
 
 # Nombre de partitions Parquet en Bronze (le gzip source est non-splittable :
 # repartitionner débloque le parallélisme des étapes aval).

--- a/webapp/docker/dev/Dockerfile
+++ b/webapp/docker/dev/Dockerfile
@@ -5,6 +5,8 @@ ARG USER_GID=1000
 
 # Aligner l'UID/GID de l'utilisateur node avec l'utilisateur local
 RUN delgroup node 2>/dev/null; deluser node 2>/dev/null; \
+    EXISTING=$(getent group ${USER_GID} | cut -d: -f1); \
+    [ -n "$EXISTING" ] && delgroup "$EXISTING" 2>/dev/null; \
     addgroup -g ${USER_GID} node && \
     adduser -u ${USER_UID} -G node -s /bin/sh -D node
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webapp",
       "version": "0.0.1",
       "dependencies": {
+        "@deck.gl/react": "^8.9.36",
         "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@deck.gl/react": "^8.9.36",
     "@fontsource-variable/dm-sans": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## Résumé
Correctifs trouvés en faisant tourner le stack complet (pipeline DVF → PostGIS → API → front) :

- **URL source geo-DVF morte** : l'ID stable data.gouv redirige vers le listing du dossier (404). Remplacée par le lien direct du millésime 2024 dans `parameters.yml`.
- **`@deck.gl/react` manquant** dans `package.json` alors qu'importé par `App.tsx` — le front ne compilait pas.
- **Build de l'image webapp dev cassé sur macOS** : GID 20 (`staff`) déjà occupé par `dialout` dans Alpine ; on évince le groupe existant avant `addgroup`.
- `.idea/` ajouté au `.gitignore`.

## Vérifié
Pipeline exécuté de bout en bout : 648k transactions / 35,6k communes en PostGIS, endpoints choropleth OK, carte affichée sur :5173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)